### PR TITLE
Add automatic module name for jigsaw (java modules system) compliancy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.4</version>
-
+                <configuration>
+                    <source>1.6</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -207,6 +209,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.0.0-M1</version>
+                        <configuration>
+                            <source>1.6</source>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.github.openjson</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
+                <version>0.8.4</version>
                 <executions>
                     <!-- Prepare execution with Surefire -->
                     <execution>


### PR DESCRIPTION
1. Picked `com.github.openjson` for a module name (will so far only be used if it is picked up as an automatic module). This is simply the highest common package name as consistent with [Stephen Colebourne's suggestion](https://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html). 

2. Added an `Automatic-Module-Name` manifest entry using the above-picked name. This ensures a base level of compliancy with jigsaw (it ensures other libraries can write a module-info while depending on this library).

3. Upgraded JaCoCo to version 0.8.4 to work around a bug with JDK11+ where JaCoCo fails to instrument core classes which have already been loaded by something else. 

4. Set source level to 1.6 for the maven javadoc plugin (as with the maven-compiler-plugin) to work around a bug with jdk11+, maven and javadoc.
(You have two different versions of the javadoc plugin configured. I set source level for both).


This way your project is minimally compliant with jigsaw in that it enables other libraries/applications to become a full module depending on this library as an automatic module. 
Please note that choosing a module name is nontrivial as you can't easily change the module name without breaking all dependent libraries and applications. Stephen Colebourne's blogpost (as linked above) contains more information about picking a good module name.

Your library could probably be trivially upgraded to a full jigsaw module but that requires it to become at the least java 9 and I thought a jump in source level of three major versions might be a bit too much. 
If you want to, however, you can probably copy what I did for [jdk-serializable-functional](https://github.com/danekja/jdk-serializable-functional/pull/11)

